### PR TITLE
Fix #1: new <outputFormatter> option to change how task output is rendered

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -5,6 +5,19 @@ const indentString = require('indent-string');
 const cliTruncate = require('cli-truncate');
 const utils = require('./utils');
 
+const defaultLineFormatter = (line, index) => {
+	const prefix = (index === 0) ? figures.arrowRight : ' ';
+	return `${prefix} ${line}`;
+};
+
+const taskOutput = (task, options, level) => {
+	const formatter = options.outputFormatter || defaultLineFormatter;
+	return task.output.split('\n').filter(Boolean).map((line, index) => {
+		const indented = indentString(formatter(line, index), level, '  ');
+		return `   ${chalk.gray(cliTruncate(indented, process.stdout.columns - 3))}`;
+	});
+};
+
 const render = (tasks, options, level) => {
 	level = level || 0;
 	let output = [];
@@ -12,15 +25,14 @@ const render = (tasks, options, level) => {
 	for (const task of tasks) {
 		if (task.isEnabled()) {
 			const skipped = task.isSkipped() ? ` ${chalk.dim('[skipped]')}` : '';
-			// Output current task title
+			// Render current task title
 			output.push(indentString(` ${utils.getSymbol(task, options)} ${task.title}${skipped}`, level, '  '));
 			// And its output
 			if ((task.isPending() || task.isSkipped() || task.hasFailed()) && utils.isDefined(task.output)) {
 				const data = task.output;
 				if (typeof data === 'string') {
-					data.split('\n').filter(Boolean).forEach((line, i) => {
-						output.push(`   ${chalk.gray(cliTruncate(indentString(`${i === 0 ? figures.arrowRight : ' '} ${line}`, level, '  '), process.stdout.columns - 3))}`);
-					});
+					const lines = taskOutput(task, options, level);
+					Array.prototype.push.apply(output, lines);
 				}
 			}
 			// And the subtasks, recursively

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # listr-multiline-renderer
 > Same as `listr-multiline-renderer` but allows multiple lines Edit
 
-Checkout the original [`listr-update-renderer`](https://github.com/SamVerschueren/listr-update-renderer) for more informations
+Checkout the original [`listr-update-renderer`](https://github.com/SamVerschueren/listr-update-renderer) for more information.
 
 ## Install
 
@@ -18,4 +18,26 @@ const Listr = require('listr');
 const list = new Listr([/* tasks */], {
 	renderer: ListrMultilineRenderer
 });
+```
+
+## Options
+
+### outputFormatter (optional)
+
+Specifies how the task output is formatted.
+
+```js
+const list = new Listr(tasks, {
+	renderer: ListrMultilineRenderer
+	outputFormatter: (line, index) => `  # ${line}`
+});
+```
+
+Default behavior is for the output to be indented, with an arrow on the first line:
+
+```
+ ⠙ Task 1
+   → First line
+     Second line
+		 Third line
 ```

--- a/test/nested.spec.js
+++ b/test/nested.spec.js
@@ -34,8 +34,8 @@ test('Sub tasks', t => {
 		}
 	];
 	const output = render(tasks, {});
-	const expected = stripAnsi(output).split('\n');
-	t.deepEqual(expected, [
+	const lines = stripAnsi(output).split('\n');
+	t.deepEqual(lines, [
 		' ❯ Task 1',
 		'   ⠙ Task 1A',
 		'   Task 2'

--- a/test/output.spec.js
+++ b/test/output.spec.js
@@ -16,32 +16,10 @@ test('Single-line output', t => {
 		}
 	];
 	const output = render(tasks, {});
-	const expected = stripAnsi(output).split('\n');
-	t.deepEqual(expected, [
+	const lines = stripAnsi(output).split('\n');
+	t.deepEqual(lines, [
 		' ⠙ Task 1',
 		'   → Hello'
-	]);
-});
-
-test('Multi-line output', t => {
-	const tasks = [
-		{
-			title: 'Task 1',
-			subtasks: [],
-			output: 'Hello\nWorld',
-			isEnabled: () => true,
-			isCompleted: () => false,
-			isPending: () => true,
-			isSkipped: () => false,
-			hasFailed: () => false
-		}
-	];
-	const output = render(tasks, {});
-	const expected = stripAnsi(output).split('\n');
-	t.deepEqual(expected, [
-		' ⠙ Task 1',
-		'   → Hello',
-		'     World'
 	]);
 });
 
@@ -69,8 +47,8 @@ test('Nested with output', t => {
 		}
 	];
 	const output = render(tasks, {});
-	const expected = stripAnsi(output).split('\n');
-	t.deepEqual(expected, [
+	const lines = stripAnsi(output).split('\n');
+	t.deepEqual(lines, [
 		' ❯ Task 1',
 		'   ⠙ Task 1A',
 		'     → Hello'

--- a/test/states.spec.js
+++ b/test/states.spec.js
@@ -15,8 +15,8 @@ test('In progress', t => {
 		}
 	];
 	const output = render(tasks, {});
-	const expected = stripAnsi(output).split('\n');
-	t.deepEqual(expected, [
+	const lines = stripAnsi(output).split('\n');
+	t.deepEqual(lines, [
 		' ⠙ Task 1'
 	]);
 });
@@ -34,8 +34,8 @@ test('Completed successfully', t => {
 		}
 	];
 	const output = render(tasks, {});
-	const expected = stripAnsi(output).split('\n');
-	t.deepEqual(expected, [
+	const lines = stripAnsi(output).split('\n');
+	t.deepEqual(lines, [
 		' ✔ Task 1'
 	]);
 });
@@ -53,8 +53,8 @@ test('Failed', t => {
 		}
 	];
 	const output = render(tasks, {});
-	const expected = stripAnsi(output).split('\n');
-	t.deepEqual(expected, [
+	const lines = stripAnsi(output).split('\n');
+	t.deepEqual(lines, [
 		' ✖ Task 1'
 	]);
 });
@@ -72,8 +72,8 @@ test('Skipped', t => {
 		}
 	];
 	const output = render(tasks, {});
-	const expected = stripAnsi(output).split('\n');
-	t.deepEqual(expected, [
+	const lines = stripAnsi(output).split('\n');
+	t.deepEqual(lines, [
 		' ↓ Task 1 [skipped]'
 	]);
 });


### PR DESCRIPTION
Here's a PR that allows to configure the output prefix.

I initially added many options like `prefixSymbol = '→'`, `repeatPrefix = true` etc... but in the end it seemed simpler to offer the option of a custom formatter. Let me know what you think.

Usage:

```js
const list = new Listr(tasks, {
  renderer: ListrMultilineRenderer,
  outputFormatter: line => `→ ${line}`
});
```
